### PR TITLE
Wrap initializing function call in $timeout

### DIFF
--- a/src/slick.js
+++ b/src/slick.js
@@ -143,8 +143,9 @@ angular
                   return slick.slideHandler(currentIndex);
                 }
               });
-
-              slickness.slick(options);
+              $timeout(function() {
+                slickness.slick(options);
+              });
             }
 
             scope.internalControl = options.method || {};


### PR DESCRIPTION
In case the elements to be slided are generated using nested transcluded angular directives (including ng-repeat) the slick initialization happens before all elements are available in the DOM.
As an example see https://github.com/vasyabigi/angular-slick/blob/master/dist/slick.js which also uses the $timeout approach.