### PR TITLE
fix an issue

### DIFF
--- a/src/slick.js
+++ b/src/slick.js
@@ -245,7 +245,7 @@ angular
           });
 
           return scope.$watch('settings', function (newVal, oldVal) {
-            if (newVal !== null) {
+            if (typeof newVal !== 'undefined' && newVal !== null) {
               return destroyAndInit();
             }
           }, true);


### PR DESCRIPTION
when value of settings is undefined, unslick throws this Error:
Cannot read property 'add' of null